### PR TITLE
Add live departures animation and interactive selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Monster Travel Teletext</title>
     <link rel="stylesheet" href="styles.css" />
+    <script src="script.js" defer></script>
   </head>
   <body>
     <main class="teletext-screen" role="main">
@@ -43,37 +44,94 @@
 
       <div class="divider divider--mid"></div>
 
+      <section class="departures" aria-label="Live departures board">
+        <header class="departures-header">
+          <h2 class="departures-title">Live Departures</h2>
+          <p class="departures-note">Updating every few seconds</p>
+        </header>
+        <div class="departures-board">
+          <button class="departure-row" type="button">
+            <span class="departure-cell departure-cell--flight" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--destination" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--time" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--gate" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--status" aria-hidden="true"></span>
+          </button>
+          <button class="departure-row" type="button">
+            <span class="departure-cell departure-cell--flight" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--destination" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--time" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--gate" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--status" aria-hidden="true"></span>
+          </button>
+          <button class="departure-row" type="button">
+            <span class="departure-cell departure-cell--flight" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--destination" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--time" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--gate" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--status" aria-hidden="true"></span>
+          </button>
+          <button class="departure-row" type="button">
+            <span class="departure-cell departure-cell--flight" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--destination" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--time" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--gate" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--status" aria-hidden="true"></span>
+          </button>
+          <button class="departure-row" type="button">
+            <span class="departure-cell departure-cell--flight" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--destination" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--time" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--gate" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--status" aria-hidden="true"></span>
+          </button>
+          <button class="departure-row" type="button">
+            <span class="departure-cell departure-cell--flight" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--destination" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--time" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--gate" aria-hidden="true"></span>
+            <span class="departure-cell departure-cell--status" aria-hidden="true"></span>
+          </button>
+        </div>
+      </section>
+
       <section class="offers">
         <div class="offers-heading">Sunny getaways • 7 nights • departing weekly</div>
         <div class="offers-columns">
           <div class="offer-column">
-            <div class="offer"><span class="destination">Algarve</span><span class="price">£175</span></div>
-            <div class="offer"><span class="destination">Majorca</span><span class="price">£189</span></div>
-            <div class="offer"><span class="destination">Tunisia</span><span class="price">£199</span></div>
-            <div class="offer"><span class="destination">Turkey</span><span class="price">£199</span></div>
-            <div class="offer"><span class="destination">Benidorm</span><span class="price">£203</span></div>
-            <div class="offer"><span class="destination">Greece</span><span class="price">£209</span></div>
-            <div class="offer"><span class="destination">Cyprus</span><span class="price">£234</span></div>
-            <div class="offer"><span class="destination">×4 Malta</span><span class="price">£249</span></div>
-            <div class="offer"><span class="destination">4× C. D. Sol</span><span class="price">£235</span></div>
+            <button class="offer" type="button" data-destination="Algarve" data-price="£175"><span class="destination">Algarve</span><span class="price">£175</span></button>
+            <button class="offer" type="button" data-destination="Majorca" data-price="£189"><span class="destination">Majorca</span><span class="price">£189</span></button>
+            <button class="offer" type="button" data-destination="Tunisia" data-price="£199"><span class="destination">Tunisia</span><span class="price">£199</span></button>
+            <button class="offer" type="button" data-destination="Turkey" data-price="£199"><span class="destination">Turkey</span><span class="price">£199</span></button>
+            <button class="offer" type="button" data-destination="Benidorm" data-price="£203"><span class="destination">Benidorm</span><span class="price">£203</span></button>
+            <button class="offer" type="button" data-destination="Greece" data-price="£209"><span class="destination">Greece</span><span class="price">£209</span></button>
+            <button class="offer" type="button" data-destination="Cyprus" data-price="£234"><span class="destination">Cyprus</span><span class="price">£234</span></button>
+            <button class="offer" type="button" data-destination="Malta" data-price="£249"><span class="destination">×4 Malta</span><span class="price">£249</span></button>
+            <button class="offer" type="button" data-destination="Costa Del Sol" data-price="£235"><span class="destination">4× C. D. Sol</span><span class="price">£235</span></button>
           </div>
           <div class="offer-column">
-            <div class="offer"><span class="destination">G. Canaria</span><span class="price">£249</span></div>
-            <div class="offer"><span class="destination">Tenerife</span><span class="price">£255</span></div>
-            <div class="offer"><span class="destination">F'Ventura</span><span class="price">£255</span></div>
-            <div class="offer"><span class="destination">Lanzarote</span><span class="price">£259</span></div>
-            <div class="offer"><span class="destination">Madeira</span><span class="price">£279</span></div>
-            <div class="offer"><span class="destination">Hurghada</span><span class="price">£289</span></div>
-            <div class="offer"><span class="destination">×4 Sharm</span><span class="price">£309</span></div>
-            <div class="offer"><span class="destination">×4 Taba</span><span class="price">£309</span></div>
-            <div class="offer"><span class="destination">Caribbean</span><span class="price">£659</span></div>
+            <button class="offer" type="button" data-destination="Gran Canaria" data-price="£249"><span class="destination">G. Canaria</span><span class="price">£249</span></button>
+            <button class="offer" type="button" data-destination="Tenerife" data-price="£255"><span class="destination">Tenerife</span><span class="price">£255</span></button>
+            <button class="offer" type="button" data-destination="Fuerteventura" data-price="£255"><span class="destination">F'Ventura</span><span class="price">£255</span></button>
+            <button class="offer" type="button" data-destination="Lanzarote" data-price="£259"><span class="destination">Lanzarote</span><span class="price">£259</span></button>
+            <button class="offer" type="button" data-destination="Madeira" data-price="£279"><span class="destination">Madeira</span><span class="price">£279</span></button>
+            <button class="offer" type="button" data-destination="Hurghada" data-price="£289"><span class="destination">Hurghada</span><span class="price">£289</span></button>
+            <button class="offer" type="button" data-destination="Sharm El Sheikh" data-price="£309"><span class="destination">×4 Sharm</span><span class="price">£309</span></button>
+            <button class="offer" type="button" data-destination="Taba" data-price="£309"><span class="destination">×4 Taba</span><span class="price">£309</span></button>
+            <button class="offer" type="button" data-destination="Caribbean" data-price="£659"><span class="destination">Caribbean</span><span class="price">£659</span></button>
           </div>
         </div>
       </section>
 
+      <section class="cta-panel" aria-live="polite">
+        <p class="cta-panel__prompt">Tap a departure or holiday to preview the details.</p>
+        <p class="cta-panel__selection" data-selection>Choose an option to get started.</p>
+        <a class="cta-panel__action" href="tel:08002802560">Call 0800 280 2560 to book</a>
+      </section>
+
       <div class="message">Call us free for more monster deals</div>
 
-      <div class="phone">0800 280 2560</div>
+      <a class="phone" href="tel:08002802560">0800 280 2560</a>
 
       <footer class="footer">
         <p class="footer-note">

--- a/script.js
+++ b/script.js
@@ -1,0 +1,106 @@
+const boardData = [
+  { flight: "MT101", destination: "LONDON", time: "12:40", gate: "A4", status: "BOARDING" },
+  { flight: "MT215", destination: "PARIS", time: "13:05", gate: "B1", status: "LAST CALL" },
+  { flight: "MT330", destination: "ROME", time: "13:20", gate: "C2", status: "ON TIME" },
+  { flight: "MT452", destination: "BERLIN", time: "13:45", gate: "A8", status: "DELAYED" },
+  { flight: "MT509", destination: "ATHENS", time: "14:00", gate: "B4", status: "GATE OPEN" },
+  { flight: "MT612", destination: "MADRID", time: "14:10", gate: "C5", status: "BOARDING" },
+  { flight: "MT784", destination: "DUBLIN", time: "14:35", gate: "A3", status: "ON TIME" },
+  { flight: "MT845", destination: "LISBON", time: "14:50", gate: "B6", status: "BOARDING" },
+  { flight: "MT912", destination: "BARCELONA", time: "15:05", gate: "C1", status: "FINAL CALL" },
+  { flight: "MT980", destination: "AMSTERDAM", time: "15:20", gate: "A5", status: "ON TIME" },
+  { flight: "MT104", destination: "DUBAI", time: "15:40", gate: "D2", status: "BOARDING" },
+  { flight: "MT118", destination: "NEW YORK", time: "16:05", gate: "E1", status: "CHECK-IN" }
+];
+
+const departureRows = Array.from(document.querySelectorAll(".departure-row"));
+const offers = Array.from(document.querySelectorAll(".offer"));
+const selectionOutput = document.querySelector("[data-selection]");
+const ctaPanel = document.querySelector(".cta-panel");
+let boardIndex = 0;
+
+function refreshBoard() {
+  if (!departureRows.length) {
+    return;
+  }
+
+  departureRows.forEach((row, rowIndex) => {
+    const data = boardData[(boardIndex + rowIndex) % boardData.length];
+
+    row.dataset.flight = data.flight;
+    row.dataset.destination = data.destination;
+    row.dataset.time = data.time;
+    row.dataset.gate = data.gate;
+    row.dataset.status = data.status;
+
+    row.querySelector(".departure-cell--flight").textContent = data.flight;
+    row.querySelector(".departure-cell--destination").textContent = data.destination;
+    row.querySelector(".departure-cell--time").textContent = data.time;
+    row.querySelector(".departure-cell--gate").textContent = data.gate;
+    row.querySelector(".departure-cell--status").textContent = data.status;
+
+    row.setAttribute(
+      "aria-label",
+      `${data.flight} to ${data.destination}, ${data.status} at ${data.time} from gate ${data.gate}`
+    );
+
+    row.classList.remove("is-flipping");
+    row.classList.remove("is-selected");
+    // Trigger reflow to restart the animation
+    void row.offsetWidth;
+    row.classList.add("is-flipping");
+  });
+
+  boardIndex = (boardIndex + departureRows.length) % boardData.length;
+}
+
+function clearSelections() {
+  [...departureRows, ...offers].forEach((item) => item.classList.remove("is-selected"));
+}
+
+function updateSelection(message) {
+  if (!selectionOutput) {
+    return;
+  }
+
+  selectionOutput.textContent = message;
+  if (ctaPanel) {
+    ctaPanel.classList.add("cta-panel--active");
+  }
+}
+
+function bindBoardInteractions() {
+  departureRows.forEach((row) => {
+    row.addEventListener("animationend", () => {
+      row.classList.remove("is-flipping");
+    });
+
+    row.addEventListener("click", () => {
+      clearSelections();
+      row.classList.add("is-selected");
+      updateSelection(
+        `${row.dataset.flight} to ${row.dataset.destination} ${row.dataset.status?.toLowerCase()} at ${row.dataset.time} (Gate ${row.dataset.gate})`
+      );
+    });
+  });
+}
+
+function bindOfferInteractions() {
+  offers.forEach((offer) => {
+    offer.addEventListener("click", () => {
+      clearSelections();
+      offer.classList.add("is-selected");
+      const destination = offer.dataset.destination;
+      const price = offer.dataset.price;
+      updateSelection(`${destination} from ${price}. Tap call to reserve your seat.`);
+    });
+  });
+}
+
+refreshBoard();
+bindBoardInteractions();
+bindOfferInteractions();
+
+if (departureRows.length) {
+  setInterval(refreshBoard, 7000);
+}

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,22 @@ body {
   padding: 48px 24px;
 }
 
+button {
+  font: inherit;
+}
+
+button,
+a {
+  color: inherit;
+}
+
+button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
 .teletext-screen {
   background: var(--black);
   border: 6px solid #02003d;
@@ -164,6 +180,125 @@ body {
   margin: 12px 0 0;
 }
 
+.departures {
+  border-bottom: 6px solid var(--yellow);
+  border-top: 6px solid var(--yellow);
+  margin: 0;
+  padding: 24px 24px 12px;
+  background: #06080f;
+}
+
+.departures-header {
+  align-items: baseline;
+  color: var(--yellow);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  letter-spacing: 0.3em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+}
+
+.departures-title {
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  margin: 0;
+}
+
+.departures-note {
+  color: var(--cyan);
+  font-size: clamp(0.75rem, 2.4vw, 0.9rem);
+  margin: 0;
+}
+
+.departures-board {
+  background: #020409;
+  border: 4px solid #0d0d0d;
+  box-shadow: inset 0 0 0 4px #010206;
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+}
+
+.departure-row {
+  align-items: center;
+  background: linear-gradient(180deg, #11161c 0%, #010206 100%);
+  border: 2px solid #050b16;
+  box-shadow: inset 0 0 0 2px rgba(248, 214, 78, 0.2);
+  color: #f8d64e;
+  display: grid;
+  font-size: clamp(0.9rem, 2.8vw, 1.1rem);
+  gap: 8px;
+  grid-template-columns: 1fr 2.2fr auto auto auto;
+  letter-spacing: 0.18em;
+  padding: 10px 12px;
+  position: relative;
+  text-transform: uppercase;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.departure-row::after {
+  border: 1px solid rgba(248, 214, 78, 0.35);
+  content: "";
+  inset: 4px;
+  pointer-events: none;
+  position: absolute;
+}
+
+.departure-row:hover,
+.departure-row:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(248, 214, 78, 0.35), 0 0 12px rgba(248, 214, 78, 0.25);
+  transform: translateY(-1px);
+}
+
+.departure-row:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+}
+
+.departure-row.is-selected {
+  box-shadow: inset 0 0 0 2px var(--cyan), 0 0 12px rgba(0, 255, 255, 0.5);
+  color: var(--cyan);
+}
+
+.departure-row.is-flipping {
+  animation: departure-flip 480ms ease;
+}
+
+.departure-cell--flight {
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.departure-cell--status {
+  justify-self: end;
+  text-align: right;
+}
+
+.departure-cell--gate,
+.departure-cell--time {
+  justify-self: center;
+}
+
+@keyframes departure-flip {
+  0% {
+    transform: rotateX(0deg);
+    opacity: 1;
+  }
+  45% {
+    transform: rotateX(-88deg);
+    opacity: 0;
+  }
+  55% {
+    transform: rotateX(88deg);
+    opacity: 0;
+  }
+  100% {
+    transform: rotateX(0deg);
+    opacity: 1;
+  }
+}
+
 .offers {
   border: 6px solid #001f8a;
   border-left: none;
@@ -200,6 +335,7 @@ body {
   letter-spacing: 0.18em;
   padding: 4px 0;
   text-transform: uppercase;
+  transition: transform 120ms ease, color 120ms ease;
 }
 
 .offer .destination {
@@ -209,6 +345,82 @@ body {
 .offer .price {
   color: var(--yellow);
   font-weight: 700;
+}
+
+.offer:hover,
+.offer:focus-visible {
+  transform: translateX(4px);
+}
+
+.offer:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+}
+
+.offer.is-selected .destination {
+  color: var(--yellow);
+}
+
+.offer.is-selected .price {
+  color: var(--cyan);
+}
+
+.cta-panel {
+  border: 6px solid var(--magenta);
+  margin: 24px;
+  padding: 18px 24px;
+  text-align: center;
+  background: rgba(255, 0, 144, 0.08);
+  display: grid;
+  gap: 12px;
+}
+
+.cta-panel--active {
+  box-shadow: 0 0 24px rgba(255, 0, 144, 0.35);
+}
+
+.cta-panel__prompt {
+  color: var(--yellow);
+  font-size: clamp(0.9rem, 2.6vw, 1.1rem);
+  letter-spacing: 0.18em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.cta-panel__selection {
+  color: var(--cyan);
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+  letter-spacing: 0.14em;
+  margin: 0;
+  min-height: 1.5em;
+  text-transform: uppercase;
+}
+
+.cta-panel__action {
+  background: var(--green);
+  border: 4px solid var(--yellow);
+  color: var(--yellow);
+  display: inline-flex;
+  font-size: clamp(1.1rem, 3vw, 1.3rem);
+  font-weight: 700;
+  justify-content: center;
+  letter-spacing: 0.22em;
+  margin: 0 auto;
+  padding: 12px 24px;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.cta-panel__action:hover,
+.cta-panel__action:focus-visible {
+  box-shadow: 0 0 16px rgba(0, 255, 89, 0.45);
+  transform: translateY(-2px);
+}
+
+.cta-panel__action:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
 }
 
 .message {
@@ -234,6 +446,8 @@ body {
   text-align: center;
   text-transform: uppercase;
   text-shadow: 0 0 12px rgba(0, 0, 0, 0.6);
+  display: block;
+  text-decoration: none;
 }
 
 .footer {
@@ -274,5 +488,65 @@ body {
 
   .masthead-graphic .sun {
     top: -8px;
+  }
+}
+
+@media (max-width: 540px) {
+  .offers {
+    padding: 18px 20px 12px;
+  }
+
+  .offers-columns {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px 24px;
+  }
+
+  .departures {
+    padding: 20px 16px 10px;
+  }
+}
+
+@media (max-width: 400px) {
+  .offers {
+    padding: 18px 16px 12px;
+  }
+
+  .offers-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .departures-board {
+    padding: 12px 8px;
+  }
+
+  .departure-row {
+    grid-template-columns: 1.1fr 2.3fr auto;
+    grid-template-areas:
+      "flight destination destination"
+      "time gate status";
+    text-align: left;
+  }
+
+  .departure-cell--flight {
+    grid-area: flight;
+  }
+
+  .departure-cell--destination {
+    grid-area: destination;
+  }
+
+  .departure-cell--time {
+    grid-area: time;
+    justify-self: start;
+  }
+
+  .departure-cell--gate {
+    grid-area: gate;
+    justify-self: start;
+  }
+
+  .departure-cell--status {
+    grid-area: status;
+    justify-self: start;
   }
 }


### PR DESCRIPTION
## Summary
- add a live departures board with animated split-flap style updates and selection highlighting
- make holiday offers interactive with a guided call-to-action panel and click-to-call phone link
- tune responsive styles so the offers grid stays within narrow mobile viewports

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0072389748328ad82b21aa3349e4b